### PR TITLE
Incorporate build into the serve command

### DIFF
--- a/{{cookiecutter.repo_name}}/package.json
+++ b/{{cookiecutter.repo_name}}/package.json
@@ -21,7 +21,7 @@
     "build": "react-scripts build && react-snapshot",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
-    "serve": "cd build && serve && cd .."
+    "serve": "yarn build && cd build && serve && cd .."
   },
   "eslintConfig": {
     "extends": "react-app"


### PR DESCRIPTION
Both @scottpdo and I have done this multiple times now where we want to see the production build, but forget to actually run the build command first.

Simple fix, incorporate the build command into the serve command.